### PR TITLE
55048: Revert changes in Review intern

### DIFF
--- a/aspnet-core/src/Timesheet.Application/APIs/ReviewDetails/ReviewDetailAppService.cs
+++ b/aspnet-core/src/Timesheet.Application/APIs/ReviewDetails/ReviewDetailAppService.cs
@@ -98,7 +98,8 @@ namespace Timesheet.APIs.ReviewDetails
                            };
             var listNote = qnote.ToList();
             var reviewDetails = from rv in WorkScope.GetAll<ReviewDetail>()
-                                .Where(s => s.InterShip.Level <= UserLevel.Intern_3 || s.Status == ReviewInternStatus.SentEmail)
+                                //Tạm thời chưa sửa, chờ thêm thông tin
+                                //.Where(s => s.InterShip.Level <= UserLevel.Intern_3 || s.Status == ReviewInternStatus.SentEmail)
                                         .Where(s => !branchId.HasValue || s.InterShip.BranchId == branchId)
                                      .Where(x => x.ReviewId == reviewId
                                      && (levelChange != null && valueLevelChange > -1 ? (valueLevelChange == 2 ? x.NewLevel == x.CurrentLevel : x.NewLevel != x.CurrentLevel) : true))

--- a/aspnet-core/src/Timesheet.Application/APIs/ReviewDetails/ReviewDetailAppService.cs
+++ b/aspnet-core/src/Timesheet.Application/APIs/ReviewDetails/ReviewDetailAppService.cs
@@ -98,7 +98,7 @@ namespace Timesheet.APIs.ReviewDetails
                            };
             var listNote = qnote.ToList();
             var reviewDetails = from rv in WorkScope.GetAll<ReviewDetail>()
-                                .Where(s => s.InterShip.Level <= UserLevel.Intern_3)
+                                .Where(s => s.InterShip.Level <= UserLevel.Intern_3 || s.Status == ReviewInternStatus.SentEmail)
                                         .Where(s => !branchId.HasValue || s.InterShip.BranchId == branchId)
                                      .Where(x => x.ReviewId == reviewId
                                      && (levelChange != null && valueLevelChange > -1 ? (valueLevelChange == 2 ? x.NewLevel == x.CurrentLevel : x.NewLevel != x.CurrentLevel) : true))


### PR DESCRIPTION
Trong review intern, khi user lên fresher, trong những tháng user đó được duyệt lên 1 level mới(trạng thái "sent email") thì không ẩn.