### PR TITLE
#256 show project non PM

### DIFF
--- a/angular/src/app/modules/project-manager/project-manager.component.html
+++ b/angular/src/app/modules/project-manager/project-manager.component.html
@@ -59,7 +59,7 @@
                   <span align="start" style="line-height: 3; padding-left: 5px;">
                     {{project.name}} [{{project.code}}]
                   </span>
-                  <span class="pm">{{project.pms.join(', ')}} </span>
+                  <span class="pm">{{project.pms.length ? project.pms.join(', ') : 'null'}} </span>
                   <span class="member">{{project.activeMember}} members</span>
                   <span *ngIf="project.projectType == 3" class="pType">ODC</span>
                   <span *ngIf="project.projectType == 2" class="pType">NB</span>

--- a/aspnet-core/src/Timesheet.Application/APIs/Timesheets/Projects/ProjectAppService.cs
+++ b/aspnet-core/src/Timesheet.Application/APIs/Timesheets/Projects/ProjectAppService.cs
@@ -397,21 +397,25 @@ namespace Timesheet.Timesheets.Projects
             var projects = qproject.Where(s => projectIds.Contains(s.Id)).AsNoTracking().AsEnumerable();
 
             var results = (from p in projects
-                           join members in projectMembers on p.Id equals members.ProjectId
-                           join pm in PMs on p.Id equals pm.ProjectId
-                           select new GetProjectDto
-                           {
-                               CustomerName = p.CustomerName,
-                               Id = p.Id,
-                               Name = p.Name,
-                               Code = p.Code,
-                               Status = p.Status,
-                               ProjectType = p.ProjectType,
-                               Pms = pm.PMs,
-                               ActiveMember = members.Count,
-                               TimeStart = p.TimeStart,
-                               TimeEnd = p.TimeEnd
-                           }).ToList();
+                          join members in projectMembers 
+                                on p.Id equals members.ProjectId into projectMembersGj
+                          from projectMembersSubGroup in projectMembersGj.DefaultIfEmpty()
+                          join pms in PMs
+                                on p.Id equals pms.ProjectId into projectPmsGj
+                          from projectPms in projectPmsGj.DefaultIfEmpty()
+                          select new GetProjectDto
+                          {
+                              CustomerName = p.CustomerName,
+                              Id = p.Id,
+                              Name = p.Name,
+                              Code = p.Code,
+                              Status = p.Status,
+                              ProjectType = p.ProjectType,
+                              Pms = projectPms?.PMs ?? new List<string>(),
+                              ActiveMember = projectMembersSubGroup?.Count ?? 0,
+                              TimeStart = p.TimeStart,
+                              TimeEnd = p.TimeEnd
+                          }).ToList();
             return results;
         }
 


### PR DESCRIPTION
## Chi tiết
Project Management => Khi chọn All Projects => Show ra tất cả Project kể cả dự án đó ko có PM (hoặc để PM là Null)

Bonus: Hiển thị nếu không có member nào (hiển thị 0 members)

## Arrange
### Project không PM
Tạo project không có PM -> xoá/đổi role ProjectUser là PM của một Project
- ProjectId: 20264
- ProjectName: BlackPink
- UserId: 51257

Change role SQL:
```sql
UPDATE local_timesheet.dbo.ProjectUsers
SET Type = 0 -- member
WHERE UserId = 51257 and ProjectId = 20264;
```

Validate role SQL:
```sql
Select * from ProjectUsers where UserId = 51257 and ProjectId = 20264
```

Validate data SQL:
```sql
-- chọn các project id sao cho số lượng pm = 0 (type PM = 1)
SELECT 
SELECT 
    p.Id, 
    COUNT(pu.Id) as memberCount,
    SUM(CASE WHEN pu.Type = 1 THEN 1 ELSE 0 END) as PMCount
FROM 
    [local_timesheet].[dbo].[Projects] as p
LEFT JOIN 
    [local_timesheet].[dbo].[ProjectUsers] as pu 
    ON p.Id = pu.ProjectId
WHERE p.IsDeleted = 0
GROUP BY p.Id
HAVING SUM(CASE WHEN pu.Type = 1 THEN 1 ELSE 0 END) = 0
```

### Bonus: Project không member
Tạo project không có member -> xoá (mềm) toàn bộ ProjectUser của một Project
- ProjectId: 20272
- ProjectName: Thao Auto

View ProjectUsers from 20272
```sql
SELECT [Id]
      ,[IsDeleted]
      ,[UserId]
      ,[ProjectId]
      ,[Type]
      ,[IsTemp]
  FROM [local_timesheet].[dbo].[ProjectUsers]
  where ProjectId = 20272
```
Soft delete
```sql
UPDATE local_timesheet.dbo.ProjectUsers
SET IsDeleted = 1
WHERE ProjectId = 20272;
```

## Action
Chọn tất cả project chưa bị xoá mềm (```isDeleted = 0```)

SQL:
```sql
SELECT Count(*)
  FROM [local_timesheet].[dbo].[Projects] as p
  Where p.IsDeleted = 0
```

## Validate
- Số lượng chọn tất cả project chưa bị xoá mềm == hiển thị trên UI -> **OK**
- Các project không có PM set PMs == null trên UI -> không hiện project -> **cần check**
```
/api/services/app/Project/GetAll?Search=BlackPink
```
## Root cause
- Endpoint: /api/services/app/Project/GetAll

Việc inner join khi các điều kiện join không thoả mãn sẽ không trả về dữ liệu, mặc dù đã lấy được projects, pms, member count 
```csharp
//var results = (from p in projects
//               join members in projectMembers on p.Id equals members.ProjectId
//               join pm in PMs on p.Id equals pm.ProjectId
//               select new GetProjectDto
//               {
//                   CustomerName = p.CustomerName,
//                   Id = p.Id,
//                   Name = p.Name,
//                   Code = p.Code,
//                   Status = p.Status,
//                   ProjectType = p.ProjectType,
//                   Pms = pm.PMs,
//                   ActiveMember = members.Count,
//                   TimeStart = p.TimeStart,
//                   TimeEnd = p.TimeEnd
//               }).ToList();
```
**Hướng giải quyết:** sử dụng left outer join với left là project
```csharp
var results = (from p in projects
              join members in projectMembers 
                    on p.Id equals members.ProjectId into projectMembersGj
              from projectMembersSubGroup in projectMembersGj.DefaultIfEmpty()
              join pms in PMs
                    on p.Id equals pms.ProjectId into projectPmsGj
              from projectPms in projectPmsGj.DefaultIfEmpty()
              select new GetProjectDto
              {
                  CustomerName = p.CustomerName,
                  Id = p.Id,
                  Name = p.Name,
                  Code = p.Code,
                  Status = p.Status,
                  ProjectType = p.ProjectType,
                  Pms = projectPms?.PMs ?? new List<string>(),
                  ActiveMember = projectMembersSubGroup?.Count ?? 0,
                  TimeStart = p.TimeStart,
                  TimeEnd = p.TimeEnd
              }).ToList();
```
