### PR TITLE
#263 Optimize Team Working Calendar, Filter by request type: Remote

### DIFF
--- a/aspnet-core/src/Timesheet.Application/APIs/RequestDays/RequestDayAppService.cs
+++ b/aspnet-core/src/Timesheet.Application/APIs/RequestDays/RequestDayAppService.cs
@@ -1700,8 +1700,8 @@ namespace Timesheet.APIs.RequestDays
             var predicate = await GetPredicate(input.projectIds);
 
             // Adjust start and end dates to ensure proper week calculations
-            var startDate = DateTimeUtils.FirstDayOfWeek(DateTimeUtils.FirstDayOfMonth(input.date));
-            var endDate = DateTimeUtils.LastDayOfWeek(DateTimeUtils.LastDayOfMonth(input.date));
+            var startDate = DateTimeUtils.FirstDayOfWeek(input.date);
+            var endDate = DateTimeUtils.LastDayOfWeek(input.date);
 
             var result = await (from s in WorkScope.GetAll<AbsenceDayDetail>()
                   .Where(s => s.DateAt >= startDate && s.DateAt <= endDate)

--- a/aspnet-core/src/Timesheet.Application/APIs/RequestDays/RequestDayAppService.cs
+++ b/aspnet-core/src/Timesheet.Application/APIs/RequestDays/RequestDayAppService.cs
@@ -1,6 +1,7 @@
 ﻿using Abp.Application.Services.Dto;
 using Abp.Authorization;
 using Abp.BackgroundJobs;
+using Abp.Collections.Extensions;
 using Abp.Configuration;
 using Abp.Linq.Extensions;
 using Abp.Logging;
@@ -1570,24 +1571,32 @@ namespace Timesheet.APIs.RequestDays
         }
         private async Task<Expression<Func<AbsenceDayDetail, bool>>> GetPredicate(List<long> projectIds)
         {
+            // Check for permission and get branchId from current user
             var isViewBranch = await IsGrantedAsync(Ncc.Authorization.PermissionNames.AbsenceDayByProject_ViewByBranch);
 
             var branchIdByPM = await WorkScope.GetAll<User>()
                 .Where(s => s.Id == AbpSession.UserId)
                 .Select(s => s.BranchId).FirstOrDefaultAsync();
 
+            var predicate = PredicateBuilder.New<AbsenceDayDetail>();
+
+            // Early return if no projectId provided
+            if (!projectIds.Any())
+            {
+                // Add filter for absence detail with the same current user branch
+                if (isViewBranch)
+                    return predicate.And(s => s.Request.User.BranchId == branchIdByPM);
+                return predicate;
+            }
+
             var activeMemberIds = await WorkScope.GetAll<ProjectUser>()
                 .Where(s => projectIds.Contains(s.ProjectId))
                 .Where(s => s.Type != ProjectUserType.DeActive)
                 .Select(s => s.UserId).Distinct().ToListAsync();
 
-            var predicate = PredicateBuilder.New<AbsenceDayDetail>();
             if (isViewBranch)
             {
-                if (projectIds.Count() > 0)
-                    predicate.And(s => (s.Request.User.BranchId == branchIdByPM && activeMemberIds.Contains(s.Request.UserId)) || activeMemberIds.Contains(s.Request.UserId));
-                else
-                    predicate.And(s => s.Request.User.BranchId == branchIdByPM || activeMemberIds.Contains(s.Request.UserId));
+                predicate.And(s => s.Request.User.BranchId == branchIdByPM || activeMemberIds.Contains(s.Request.UserId));
             }
             else
             {
@@ -1605,26 +1614,8 @@ namespace Timesheet.APIs.RequestDays
 
             if (input.type.Value == RequestType.Remote && input.remoteOfWeek.HasValue)
             {
-                List<DateTime> weeks = new List<DateTime>();
-
-                DateTime current = input.startDate;
-                while (current <= input.endDate)
-                {
-                    if (current.DayOfWeek == DayOfWeek.Monday)
-                    {
-                        weeks.Add(current);
-                        current = current.AddDays(7);
-                    }
-                    else current = current.AddDays(-1);
-                }
-
-                var result = new List<CountRequestDto>();
-
-                foreach(DateTime monday in weeks)
-                {
-                    var query = from s in WorkScope.GetAll<AbsenceDayDetail>()
-                    .Where(s => s.DateAt >= monday)
-                    .Where(s => s.DateAt.Date <= monday.AddDays(6))
+                var query = WorkScope.GetAll<AbsenceDayDetail>()
+                    .Where(s => s.DateAt >= input.startDate && s.DateAt <= input.endDate)
                     .Where(predicate)
                     .Where(s => !input.status.HasValue || input.status.Value < 0 ||
                             (input.status.Value == 0 ? (s.Request.Status == RequestStatus.Pending || s.Request.Status == RequestStatus.Approved) :
@@ -1633,22 +1624,40 @@ namespace Timesheet.APIs.RequestDays
                     .WhereIf(input.dayType.HasValue && input.dayType.Value > 0, s => s.DateType == input.dayType.Value)
                     .WhereIf(input.BranchId.HasValue, s => s.Request.User.BranchId == input.BranchId)
                     .Where(s => string.IsNullOrWhiteSpace(input.name) || s.Request.User.EmailAddress.Contains(input.name))
-                    .Where(s => input.dayOffTypeId < 0 || s.Request.DayOffTypeId == input.dayOffTypeId)
-                                select s;
+                    .Where(s => input.dayOffTypeId < 0 || s.Request.DayOffTypeId == input.dayOffTypeId);
 
-                    var queryFilterByRemoteOfWeek = query.WhereIf(input.remoteOfWeek.Value > 0, s => query.Count(s1 => s1.CreatorUserId == s.CreatorUserId) == input.remoteOfWeek.Value)
-                        .GroupBy(s => new { s.DateAt, s.Request.Type, AbsenceType = s.AbsenceTime ?? OnDayType.None }).Select(s => new CountRequestDto
-                        {
-                            Date = s.Key.DateAt,
-                            Type = s.Key.Type,
-                            Count = s.Count(),
-                            AbsenceType = s.Key.AbsenceType
-                        });
+                var absenceDetails = await query
+                    .Select(s => new
+                    {
+                        s.DateAt,
+                        s.CreatorUserId,
+                        s.Request.Type,
+                        AbsenceType = s.AbsenceTime ?? OnDayType.None
+                    })
+                    .ToListAsync();
 
-                    var queryResult = queryFilterByRemoteOfWeek.ToList();
+                // Group elements by CreatorUserId
+                // & the first date of DateAt's week (to determine which week this DateAt falls in)
+                var weeklyAbsences = absenceDetails
+                    .GroupBy(s => new
+                    {
+                        WeekStartDate = DateTimeUtils.FirstDayOfWeek(s.DateAt),
+                        s.CreatorUserId
+                    })
+                    .Where(g => g.Count() == input.remoteOfWeek.Value)
+                    .SelectMany(g => g) // Flatten groups
+                    .ToList();
 
-                    result = result.Concat(queryResult).ToList();
-                }
+                var result = weeklyAbsences
+                    .GroupBy(s => new { s.DateAt, s.Type, s.AbsenceType })
+                    .Select(g => new CountRequestDto
+                    {
+                        Date = g.Key.DateAt,
+                        Type = g.Key.Type,
+                        Count = g.Count(),
+                        AbsenceType = g.Key.AbsenceType
+                    })
+                    .ToList();
 
                 return result;
             } else {
@@ -1690,8 +1699,12 @@ namespace Timesheet.APIs.RequestDays
             RequestStatus[] arrayAbsenceStatus = new RequestStatus[] { RequestStatus.Pending, RequestStatus.Pending, RequestStatus.Approved, RequestStatus.Rejected };
             var predicate = await GetPredicate(input.projectIds);
 
-            IQueryable<GetRequestDto> query = from s in WorkScope.GetAll<AbsenceDayDetail>()
-                  //.Where(s => s.DateAt == input.date)
+            // Adjust start and end dates to ensure proper week calculations
+            var startDate = DateTimeUtils.FirstDayOfWeek(DateTimeUtils.FirstDayOfMonth(input.date));
+            var endDate = DateTimeUtils.LastDayOfWeek(DateTimeUtils.LastDayOfMonth(input.date));
+
+            var result = await (from s in WorkScope.GetAll<AbsenceDayDetail>()
+                  .Where(s => s.DateAt >= startDate && s.DateAt <= endDate)
                   .Where(predicate)
                   .Where(s => !input.status.HasValue || input.status.Value < 0 ||
                            (input.status.Value == 0 ? (s.Request.Status == RequestStatus.Pending || s.Request.Status == RequestStatus.Approved) :
@@ -1701,54 +1714,59 @@ namespace Timesheet.APIs.RequestDays
                   .WhereIf(input.BranchId.HasValue, s => s.Request.User.BranchId == input.BranchId)
                   .Where(s => string.IsNullOrWhiteSpace(input.name) || s.Request.User.EmailAddress.Contains(input.name))
                   .Where(s => input.dayOffTypeId < 0 || s.Request.DayOffTypeId == input.dayOffTypeId)
-                        join u in qUser on s.Request.LastModifierUserId equals u.Id into updatedUser
-                        join cu in qUser on s.CreatorUserId equals cu.Id into cuu
-                        select new GetRequestDto
-                        {
-                            Id = s.Request.Id,
-                            UserId = s.Request.UserId,
-                            AvatarPath = s.Request.User.AvatarPath,
-                            Sex = s.Request.User.Sex,
-                            FullName = s.Request.User.FullName,
-                            Name = s.Request.User.Name,
-                            Type = s.Request.User.Type,
-                            DateAt = s.DateAt,
-                            DateType = s.DateType,
-                            DayOffName = s.Request.DayOffType.Name,
-                            Hour = s.Hour,
-                            Status = s.Request.Status,
-                            ShortName = s.Request.User.Name,
-                            LeavedayType = s.Request.Type,
-                            BranchDisplayName = s.Request.User.Branch.DisplayName,
-                            BranchColor = s.Request.User.Branch.Color,
-                            AbsenceTime = s.AbsenceTime,
-                            CreateTime = s.CreationTime,
-                            CreateBy = cuu.Select(x => x.FullName).FirstOrDefault(),
-                            LastModificationTime = s.Request.LastModificationTime,
-                            LastModifierUserName = updatedUser.Select(x => x.FullName).FirstOrDefault(),
-                        };
+                               join u in qUser on s.Request.LastModifierUserId equals u.Id into updatedUser
+                               join cu in qUser on s.CreatorUserId equals cu.Id into cuu
+                               select new GetRequestDto
+                               {
+                                   Id = s.Request.Id,
+                                   UserId = s.Request.UserId,
+                                   AvatarPath = s.Request.User.AvatarPath,
+                                   Sex = s.Request.User.Sex,
+                                   FullName = s.Request.User.FullName,
+                                   Name = s.Request.User.Name,
+                                   Type = s.Request.User.Type,
+                                   DateAt = s.DateAt,
+                                   DateType = s.DateType,
+                                   DayOffName = s.Request.DayOffType.Name,
+                                   Hour = s.Hour,
+                                   Status = s.Request.Status,
+                                   ShortName = s.Request.User.Name,
+                                   LeavedayType = s.Request.Type,
+                                   BranchDisplayName = s.Request.User.Branch.DisplayName,
+                                   BranchColor = s.Request.User.Branch.Color,
+                                   AbsenceTime = s.AbsenceTime,
+                                   CreateTime = s.CreationTime,
+                                   CreateBy = cuu.Select(x => x.FullName).FirstOrDefault(),
+                                   LastModificationTime = s.Request.LastModificationTime,
+                                   LastModifierUserName = updatedUser.Select(x => x.FullName).FirstOrDefault(),
+                               }).ToListAsync();
             if(input.type.Value == RequestType.Remote && input.remoteOfWeek.HasValue && input.remoteOfWeek.Value > 0)
             {
-                DateTime monday = input.date;
-                while (monday.DayOfWeek != DayOfWeek.Monday)
-                    monday = monday.AddDays(-1);
-
-                var queryCount = query.Where(s => monday <= s.DateAt && s.DateAt <= monday.AddDays(6)).Select(s => s);
-
-                query = query.Where(s => s.DateAt == input.date).Where(s => queryCount.Count(s1 => s1.UserId == s.UserId) == input.remoteOfWeek.Value).Select(s => s);
-            } else {
-                query = query.Where(s => s.DateAt == input.date).Select(s => s);
+                // Group elements by CreatorUserId
+                // & the first date of DateAt's week (to determine which week this DateAt falls in)
+                result = result.GroupBy(s => new
+                {
+                    WeekStartDate = DateTimeUtils.FirstDayOfWeek(s.DateAt),
+                    CreatorUserId = s.UserId
+                })
+                    .Where(g => g.Count() == input.remoteOfWeek.Value)
+                    .SelectMany(g => g) // Flatten groups
+                    .Where(s => s.DateAt == input.date)
+                    .ToList();
             }
-            var res = query.ToList();
+            else
+            {
+                result = result.Where(s => s.DateAt == input.date).ToList();
+            }
+            
+            var dictUserProjectInfos = await DictUserProjectInfos(result.Select(s => s.UserId));
 
-            var dictUserProjectInfos = await DictUserProjectInfos(res.Select(s => s.UserId));
-
-            res.ForEach(s =>
+            result.ForEach(s =>
             {
                 s.ProjectInfos = dictUserProjectInfos.ContainsKey(s.UserId) ? dictUserProjectInfos[s.UserId] : default;
             });
 
-            return res;
+            return result;
         }
     } 
 }


### PR DESCRIPTION
### Target teamworking calendar endpoint
- Overview: /api/services/app/RequestDay/GetCountRequestForUser
  - Condition `if (input.type.Value == RequestType.Remote && input.remoteOfWeek.HasValue) {...}`
- Detail: /api/services/app/RequestDay/GetAllRequestForUserByDay

## Debugging

- Add for console logging in
  `Timesheet.EntityFrameworkCore\EntityFrameworkCore\TimesheetDbContextConfigurer.cs`. - `Microsoft.Extensions.Logging` - `Microsoft.Extensions.Logging.Console`

Ignore `Timesheet.EntityFrameworkCore` changes in commit.

## Relevant tables

- `[AbsenceDayRequests]`: request xin nghỉ, mỗi ngày nghỉ là 1 request
- `[AbsenceDayDetails]`: thông tin về việc nghỉ, 1-1 AbsenceDayRequests.

## Relevant enums

```csharp
// AbsenceDayRequests
public enum RequestStatus
{
    All = 0,
    Pending = 1,
    Approved = 2,
    Rejected = 3,
}
public enum RequestType
{
    Off = 0,
    Onsite = 1,
    Remote = 2,
}
// AbsenceDayDetails
public enum DayType : byte
{
    Fullday = 1,
    Morning = 2,
    Afternoon = 3,
    Custom = 4,
}
public enum OnDayType : byte
{
    DiMuon = 1,
    MiddleOfDay = 2,
    VeSom = 3,
    None = 0,
}
```

# Overview: GetCountRequestForUser

## Current flow for `remote` and `remoteOfWeek`

1. Thêm tất cả các ngày thứ 2 của mỗi tuần trong khoảng startDate-endDate (từ payload) vào một list
1. Tạo một danh sách kết quả rỗng
1. Với mỗi ngày T2 trong list đó IQueryable về `AbsenceDayDetails` với điều kiện:
   - Ngày trong khoảng: thứ 2 hiện tại -> CN
   - **Predicate?** input: projectIds
     - Check quyền truy cập các ngày nghỉ theo project + theo chi nhánh hiện tại. Nếu có: Trả về filter cho query
       - `AbsenceDayDetails` cùng nhánh user hiện tại
       - Hoặc `AbsenceDayDetails` chứa thành viên là ProjectUser trong projectIds
     - Nếu không Trả về filter cho query:
       - `AbsenceDayDetails` chứa thành viên là ProjectUser trong projectIds
   - Các điều kiện lọc dữ liệu từ POST request body
   - Điều kiện số lượng đơn nghỉ của User trong tuần hiện tại phải bằng `remoteOfWeek`
     - Đạt được bằng cách execute Count() từ query dựng từ các điều kiện trước

## Approach

- Bỏ tiền xử lý ngày trên code, bỏ vòng lặp query theo tuần trên code
- Chia nhỏ truy vấn, join dữ liệu trên bộ nhớ. Chỉ cần 2 truy vấn chính
  - Q1: `CreatorUserId`, `DateAt`, `WeekDiff`
    > `WeekDiff` là khoảng cách tuần giữa `DateAt` và `input.StartDate` - đại diện cho tuần của request đó
  - Q2: `DateAt`, `Type`, `Request` là kết quả cuối cùng, dựa trên
    - Join `AbsenceDayDetails` & `AbsenceDayRequests` qua RequestId
    - Join tiếp với Q1 với điều kiện join:
      - _khoảng cách tuần_ giữa DateAt với input.StartDate là như nhau
      - cùng `CreatorUserId`

**Bad news**: Efcore 2.2 doesn't support DATEDIFF()

## Another approach

- Kéo toàn toàn bộ data request khi đi qua filter
- Tính khoảng cách tuần ở Q1 bằng code
- Group trên code
- Filter remote of week trên code
  Code

```csharp
var query = ... // get all with filters
var absenceDetails = await query
    .Select(s => new
    {
        s.DateAt,
        s.CreatorUserId,
        s.Request.Type,
        AbsenceType = s.AbsenceTime ?? OnDayType.None
    })
    .ToListAsync();

// Group elements by CreatorUserId
// & the first date of DateAt's week (to determine which week this DateAt falls in)
var weeklyAbsences = absenceDetails
    .GroupBy(s => new
    {
        WeekStartDate = DateTimeUtils.FirstDayOfWeek(s.DateAt),
        s.CreatorUserId
    })
    .Where(g => g.Count() == input.remoteOfWeek.Value)
    .SelectMany(g => g) // Flatten groups
    .ToList();

var result = weeklyAbsences
    .GroupBy(s => new { s.DateAt, s.Type, s.AbsenceType })
    .Select(g => new CountRequestDto
    {
        Date = g.Key.DateAt,
        Type = g.Key.Type,
        Count = g.Count(),
        AbsenceType = g.Key.AbsenceType
    })
    .ToList();

return result;
```

### Final estimating

- Test `Overview` with request body (return 15 objects)

```json
{
  "startDate": "2022-10-25",
  "endDate": "2022-12-07",
  "projectIds": [5, 30288, 20034, 30281, 30314, 30315, 30316],
  "name": "",
  "type": 2,
  "dayoffTypeId": -1,
  "status": -1,
  "remoteOfWeek": 5
}
```

| Request Type     | Estimated Time |
| ---------------- | -------------- |
| Local            | 0.9-1.64s      |
| Remote           | 2.3-3s         |
| Local (enhenced) | 54-450ms       |

# GetAllRequestForUserByDay

### Current flow

- Tạo IQueryable:
  - Get list AbsenceDayDetail theo filters
  - Get list User
  - Join AbsenceDayDetail với `AbsenceDayDetail.CreatorUserId` & `AbsenceDayDetail.Request.LastModifierUserId` & User với `Id` để xác định người tạo và người accept/reject -> gọi là `query`
  - Nếu có remote type & remoteOfWeek:
    - \*Tính ngày bắt đầu của tuần (thứ 2)
    - \*Thêm filter cho query chỉ chọn các ngày trong tuần (thứ 2 -> CN)
    - \*Thêm filter cho query chỉ chọn các ngày khi đếm request trong tuần của 1 user = `remoteOfWeek` và `DateAt` = `input.date`
- GetList Dto từ IQueryable
- Lấy Dict UserId-thông tin các Project và PMs của Project mà User hiện tại đang join -> ghep vào với Dto
  > '\*' là các phần chưa tối ưu

### Approach

- Tương tự như phần trước, kèo toàn bộ AbsenceDayDetail sau các filters và xử lý `remoteOfWeek` filter in-mem
- Vì chỉ đếm ngày trong tuần, giới hạn AbsenceDetail kéo về từ đầu tới cuối tuần

### Final estimating

- Test `Detail` with request body (only 1 item return)

```json
{
  "date": "2022-11-14T17:00:00.000Z",
  "projectIds": [5, 30288, 20034, 30281, 30314, 30315, 30316],
  "name": "",
  "type": 2,
  "dayoffTypeId": -1,
  "status": -1,
  "remoteOfWeek": 5
}
```

| Request Type | Estimated Time |
| ------------ | -------------- |
| Local        | 1-1.33s        |
| Remote       | 2.5-3.5s       |
| Local        | 200-400ms      |